### PR TITLE
Spelling error fixes

### DIFF
--- a/.github/workflows/check_typos.yml
+++ b/.github/workflows/check_typos.yml
@@ -19,4 +19,4 @@ jobs:
             with:
               check_filenames: true
               skip: "*.yml,*.cff,*.js,*.lock"
-              ignore_words_list: stip,leary,hsi
+              ignore_words_list: stip,leary,hsi,damon

--- a/Open_Science_Cookbook/Your_Open_Science_Journey.md
+++ b/Open_Science_Cookbook/Your_Open_Science_Journey.md
@@ -213,7 +213,7 @@ Collect open science stories about your organization, highlighting how open scie
 
 **Basic Requirements**
 
-In order to docuemnt an Open Science Story, the following elements should be included in the blog or interview:
+In order to document an Open Science Story, the following elements should be included in the blog or interview:
 * The interviewee’s personal definition of open science, and how it connects to [NASA’s definition](https://github.com/nasa/Transform-to-Open-Science/blob/main/docs/Area4_Moving_To_Openness/Open_Science.md) 
 * A description of at least one, distinct research project or scientific initiative which demonstrates open science principles or practices. 
 * Information or stories about the challenges or barriers faced when first embarking on the open science project, as well as the ultimate benefits of preserving, to help encourage others to also adopt open science. 


### PR DESCRIPTION
Fixed spelling error in 'Your Open Science Journey' ('In order to docuemnt' changed to 'In order to document') and added 'damon' to ignore list.  Let me know if for some reason we are still having some typo check issues.  This pull request may show the same warnings, but this should hopefully be resolved by the next pull request.