### PR TITLE
Update Springer Nature text per Laura

### DIFF
--- a/Year_of_Open_Science_Guide/participants/SpringerNature.md
+++ b/Year_of_Open_Science_Guide/participants/SpringerNature.md
@@ -1,9 +1,13 @@
-# Springer Nature Group
+# Springer Nature
 ```{image} /About/logos/springernature_logo.jpg
 :alt: Springer Nature logo
 :width: 150px
 :align: right
 ```
 We see the rise of open research in all its manifestations as one of the major forces reshaping the way that researchers communicate and collaborate to advance the pace and quality of discovery.
+
+Springer Nature is committed to the sustainable drive towards open science. For over twenty years, since [BMC](https://www.biomedcentral.com/p/bmc-20th-anniversary) first pioneered an open access publishing model, openness and innovation have been at the heart of our business.
+
+We offer researchers, institutions and their funders OA options for journals, books and sharing research data. We believe Gold OA publication offers the simplest most open and most sustainable route to OA and open science.
 
 Learn more at [springernature.com](https://www.springernature.com/gp/open-research/about).


### PR DESCRIPTION
Basic text changes, most notably they want to be called Springer Nature instead of Springer Nature Group.  Some additions to body text were provided as well.